### PR TITLE
style(frappe get_doc): fix typo tood to todo

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -762,7 +762,7 @@ def get_doc(*args, **kwargs):
 
 		# insert a new document
 		todo = frappe.get_doc({"doctype":"ToDo", "description": "test"})
-		tood.insert()
+		todo.insert()
 
 		# open an existing document
 		todo = frappe.get_doc("ToDo", "TD0001")


### PR DESCRIPTION
 fix typo for word "todo"
